### PR TITLE
Make includable in other content types

### DIFF
--- a/app/components/speak-the-words-util.js
+++ b/app/components/speak-the-words-util.js
@@ -1,0 +1,25 @@
+/** Class for utility functions */
+class Util {
+  /**
+   * Extend an array just like JQuery's extend.
+   * @param {object} arguments Objects to be merged.
+   * @return {object} Merged objects.
+   */
+  static extend() {
+    for (let i = 1; i < arguments.length; i++) {
+      for (let key in arguments[i]) {
+        if (arguments[i].hasOwnProperty(key)) {
+          if (typeof arguments[0][key] === 'object' && typeof arguments[i][key] === 'object') {
+            this.extend(arguments[0][key], arguments[i][key]);
+          }
+          else {
+            arguments[0][key] = arguments[i][key];
+          }
+        }
+      }
+    }
+    return arguments[0];
+  }
+}
+
+export default Util;

--- a/app/components/speak-the-words.js
+++ b/app/components/speak-the-words.js
@@ -250,10 +250,78 @@ export default class {
   }
 
   /**
+   * Get maximum score.
+   * @return {number} Maximum score.
+   */
+  getMaxScore() {
+    return 1;
+  }
+
+  /**
    * Check if question is answered.
    * @returns {boolean}
    */
   isQuestionAnswered() {
     return this.hasAnswered;
+  }
+
+  /**
+   * Get xAPI data.
+   * @param {object} wrapper H5P instance.
+   * @return {object} XAPI statement.
+   * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-6}
+   */
+  getXAPIData(wrapper) {
+    return ({
+      statement: this.getXAPIAnswerEvent(wrapper).data.statement
+    });
+  }
+
+  /**
+   * Build xAPI answer event.
+   * @param {object} wrapper H5P instance.
+   * @return {H5P.XAPIEvent} XAPI answer event.
+   */
+  getXAPIAnswerEvent(wrapper) {
+    const xAPIEvent = this.createXAPIEvent('answered', wrapper);
+
+    xAPIEvent.setScoredResult(this.getScore(), this.getMaxScore(), this,
+      true, this.getScore() === this.getMaxScore());
+
+    return xAPIEvent;
+  }
+
+  /**
+   * Create an xAPI event for SpeakTheWords.
+   * @param {string} verb Short id of the verb we want to trigger.
+   * @param {object} wrapper H5P instance.
+   * @return {H5P.XAPIEvent} Event template.
+   */
+  createXAPIEvent(verb, wrapper = {}) {
+
+    const xAPIEvent = new H5P.XAPIEvent();
+
+    xAPIEvent.setActor();
+    xAPIEvent.setVerb(verb);
+    xAPIEvent.setObject(wrapper);
+    xAPIEvent.setContext(wrapper);
+
+    Util.extend(
+      xAPIEvent.getVerifiedStatementValue(['object', 'definition']),
+      this.getxAPIDefinition());
+    return xAPIEvent;
+  }
+
+  /**
+   * Get the xAPI definition for the xAPI object.
+   * @return {object} XAPI definition.
+   */
+  getxAPIDefinition() {
+    return ({
+      name: {'en-US': H5P.createTitle('Speak the Words')},
+      description: {'en-US': this.params.question},
+      type: 'http://adlnet.gov/expapi/activities/cmi.interaction',
+      interactionType: 'other'
+    });
   }
 }

--- a/app/components/speak-the-words.js
+++ b/app/components/speak-the-words.js
@@ -7,6 +7,7 @@ import { decode } from 'he';
 import SpeechEngine from './body/speech-engine';
 import RecordButton from './body/record-button';
 import ShowSolution from './body/show-solution';
+import Util from './speak-the-words-util';
 
 /**
  * Speak the words
@@ -49,15 +50,31 @@ export default class {
    * @param {Object} question H5P Question instance with button and event functionality
    */
   constructor(params, question) {
-    params.acceptedAnswers = params.acceptedAnswers || [];
-    params.acceptedAnswers = params.acceptedAnswers.map(decode);
-    this.params = params;
+    // Set defaults
+    this.params = Util.extend({
+      question: '',
+      acceptedAnswers: [],
+      incorrectAnswerText: 'Incorrect answer',
+      correctAnswerText: 'Correct answer',
+      inputLanguage: 'en-US',
+      l10n: {
+        retryLabel: 'Retry',
+        showSolutionLabel: 'Show solution',
+        speakLabel: 'Push to speak',
+        listeningLabel: 'Listening...',
+        correctAnswersText: 'The correct answer(s):',
+        userAnswersText: 'Your answer(s) was interpreted as:',
+        noSound: 'I could not hear you, make sure your microphone is enabled',
+        unsupportedBrowserHeader: 'It looks like your browser does not support speech recognition',
+        unsupportedBrowserDetails: 'Please try again in a browser like Chrome'
+      }
+    }, params);
+
+    this.params.acceptedAnswers = this.params.acceptedAnswers.map(decode);
+
     this.question = question;
     this.hasAnswered = false;
     this.score = 0;
-
-    // Set question to empty string if undefined
-    this.params.question = this.params.question || '';
 
     // Skip rendering components if speech engine does not exist
     if (!window.annyang) {
@@ -65,25 +82,25 @@ export default class {
     }
 
     this.speechEventStore = new H5P.EventDispatcher();
-    this.createIntroduction(params.question);
-    this.createContent(params);
-    this.createButtonBar(params.l10n);
+    this.createIntroduction(this.params.question);
+    this.createContent(this.params);
+    this.createButtonBar(this.params.l10n);
 
     // Renders record button and show solution area into the question main content
     ReactDOM.render((
       <div>
         <RecordButton
           eventStore={this.speechEventStore}
-          l10n={params.l10n}
+          l10n={this.params.l10n}
           speechEngine={this.speechEngine}
         />
-        <ShowSolution eventStore={this.speechEventStore} {...params} />
+        <ShowSolution eventStore={this.speechEventStore} {...this.params} />
       </div>
     ), this.questionWrapper);
 
-    this.speechEngine = new SpeechEngine(params, this.speechEventStore);
-    this.speechEventStore.on('answered-correctly', this.answeredCorrectly.bind(this, params.correctAnswerText));
-    this.speechEventStore.on('answered-wrong', this.answeredWrong.bind(this, params.incorrectAnswerText));
+    this.speechEngine = new SpeechEngine(this.params, this.speechEventStore);
+    this.speechEventStore.on('answered-correctly', this.answeredCorrectly.bind(this, this.params.correctAnswerText));
+    this.speechEventStore.on('answered-wrong', this.answeredWrong.bind(this, this.params.incorrectAnswerText));
   }
 
   /**

--- a/app/entries/dist.js
+++ b/app/entries/dist.js
@@ -1,4 +1,5 @@
 import SpeakTheWords from '../components/speak-the-words';
+import Util from '../components/speak-the-words-util';
 import { decode } from 'he';
 
 /**
@@ -15,6 +16,13 @@ H5P.SpeakTheWords = (function (Question) {
    * @constructor
    */
   function WrapperClass(params) {
+    this.params = Util.extend({
+      behaviour: {
+        enableSolutionsButton: true, // Expected by question type contract
+        enableRetry: true // Expected by question type contract
+      }
+    }, params);
+
     Question.call(this, 'speak-the-words');
     const speakTheWords = new SpeakTheWords(params, this);
 
@@ -56,6 +64,31 @@ H5P.SpeakTheWords = (function (Question) {
     this.getScore = () => {
       return speakTheWords.getScore();
     };
+
+    /**
+     * Contract for getting maxScore.
+     * @see {@link https://h5p.org/documentation/developers/contracts}
+     * @return {number} Maximum score.
+     */
+    this.getMaxScore = () => {
+      return speakTheWords.getMaxScore();
+    };
+
+    /**
+     * Contract for getting info on whether question was answered.
+     * @see {@link https://h5p.org/documentation/developers/contracts}
+     * @return {boolean} True, if an answer was given.
+     */
+    this.getAnswerGiven = () => {
+      return speakTheWords.isQuestionAnswered();
+    };
+
+    /**
+     * Get xAPI data.
+     * @return {object} XAPI statement.
+     * @see {@link https://h5p.org/documentation/developers/contracts}
+     */
+    this.getXAPIData = () => speakTheWords.getXAPIData(this);
 
     /**
      * Stop listening for voice.


### PR DESCRIPTION
Currently, Speak the Words cannot be included in e.g. Course Presentation, because it doesn't set default values and would crash when adding it in the editor. Also, it doesn't fully implement the question type contract, so scores would not be reported on Course Presentations's summary slide.

When merged in, Speak the Words will
- set default values, so it could be used in Course Presentation
- fully implement the question type contract including getXAPIData(), so it reports scores etc.